### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ Expyrimenter
 .. image:: https://readthedocs.org/projects/expyrimenter/badge/?version=latest
    :alt: Documentation
    :target: http://expyrimenter.rtfd.org/en/latest/
-.. image:: https://pypip.in/version/expyrimenter/badge.svg
+.. image:: https://img.shields.io/pypi/v/expyrimenter.svg
    :alt: PyPI
    :target: https://pypi.python.org/pypi/expyrimenter
 .. image:: https://travis-ci.org/cemsbr/expyrimenter.svg?branch=master


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20expyrimenter))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `expyrimenter`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.